### PR TITLE
Add root redirect to API docs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
 
 from .db import init_db
 from .routers import (
@@ -29,6 +30,10 @@ def create_app() -> FastAPI:
     @app.on_event("startup")
     def _startup() -> None:
         init_db()
+
+    @app.get("/", include_in_schema=False)
+    def root() -> RedirectResponse:
+        return RedirectResponse(url="/docs", status_code=307)
 
     app.include_router(properties.router, prefix="/properties", tags=["properties"])
     app.include_router(units.router, prefix="/units", tags=["units"])

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import FastAPI, status
+from fastapi.responses import RedirectResponse
 
 from .db import init_db
 from .routers import (
@@ -31,12 +32,8 @@ def create_app() -> FastAPI:
         init_db()
 
     @app.get("/", include_in_schema=False)
-    def root() -> dict[str, str]:
-        return {
-            "status": "available",
-            "docs_url": "/docs",
-            "message": "Visit the interactive API docs at /docs",
-        }
+    def root() -> RedirectResponse:
+        return RedirectResponse(url="/docs", status_code=status.HTTP_307_TEMPORARY_REDIRECT)
 
     app.include_router(properties.router, prefix="/properties", tags=["properties"])
     app.include_router(units.router, prefix="/units", tags=["units"])

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
-from fastapi.responses import RedirectResponse
 
 from .db import init_db
 from .routers import (
@@ -32,8 +31,12 @@ def create_app() -> FastAPI:
         init_db()
 
     @app.get("/", include_in_schema=False)
-    def root() -> RedirectResponse:
-        return RedirectResponse(url="/docs", status_code=307)
+    def root() -> dict[str, str]:
+        return {
+            "status": "available",
+            "docs_url": "/docs",
+            "message": "Visit the interactive API docs at /docs",
+        }
 
     app.include_router(properties.router, prefix="/properties", tags=["properties"])
     app.include_router(units.router, prefix="/units", tags=["units"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -139,3 +139,9 @@ def test_end_to_end_workflow(client):
     issues = compliance_resp.json()
     assert any("Certification due" in issue["issue"] for issue in issues)
     assert any("exceeds limit" in issue["issue"] for issue in issues)
+
+
+def test_root_redirects_to_docs(client):
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"].endswith("/docs")


### PR DESCRIPTION
## Summary
- add a root route that issues a temporary redirect to the interactive docs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb0a2198888333abccec75f452d237