### PR TITLE
Add Vercel config to route FastAPI requests

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "builds": [
+    {
+      "src": "app/main.py",
+      "use": "@vercel/python",
+      "config": {
+        "runtime": "python3.11"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "app/main.py"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a vercel.json that uses the @vercel/python builder for app/main.py
- ensure all routes proxy to the FastAPI entrypoint instead of static hosting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb3571c98083338bcf1543a3b53687