### PR TITLE
Configure Vercel Python runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "functions": {
     "app/main.py": {
       "runtime": "python3.11"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "app/main.py": {
+      "runtime": "python3.11"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration file specifying that app/main.py should run on Python 3.11

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68cbd3909cf48333aad3ad1e2b5eea2e