### PR TITLE
Configure Vercel Python runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "app/main.py": {
+      "runtime": "@vercel/python@5.0.4"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration file that pins the Python builder used by `app/main.py`

## Testing
- `npx vercel build` *(fails: network access to Vercel endpoints is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5a3674c48333adfee30262657436