### PR TITLE
Create Vercel entrypoint for FastAPI app

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,5 @@
+"""Vercel entrypoint exposing the FastAPI application."""
+
+from app.main import app
+
+__all__ = ["app"]

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/*.py": {
+      "runtime": "python3.11"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an `api` package with an entrypoint that re-exports the FastAPI `app`
- configure `vercel.json` so Vercel discovers `api/*.py` serverless functions while keeping the Python 3.11 runtime pin

## Testing
- vercel build *(fails: requires Vercel project settings and network access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc648ac5fc8333a477dc010174f9fb