### PR TITLE
Update Vercel Python runtime config

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,5 @@
+"""Vercel serverless entrypoint exposing the FastAPI application."""
+
+from app.main import app
+
+__all__ = ["app"]

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/*.py": {
-      "runtime": "vercel-python@3.11"
+      "runtime": "@vercel/python@5.0.4"
     }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/*.py": {
-      "runtime": "@vercel/python@5.0.4"
+      "runtime": "vercel-python@3.11"
     }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/*.py": {
+      "runtime": "vercel-python@3.11"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` with the Python function runtime set to `vercel-python@3.11`

## Testing
- vercel build *(fails: unable to retrieve project settings / network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d7b07a88333a6a0c6b01da82d54