### PR TITLE
Update Vercel Python runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/*.py": {
+      "runtime": "@vercel/python@5.0.4"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a `vercel.json` configuration that sets the Python API runtime to the current package-based runtime `@vercel/python@5.0.4`

## Testing
- npx vercel@latest build *(fails: unable to reach vercel.com to download package information)*

------
https://chatgpt.com/codex/tasks/task_e_68cd44f002f08333a2d1fae6c97362c6