### PR TITLE
Expose FastAPI app through Vercel entrypoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,5 @@
+"""Vercel entrypoint for the FastAPI application."""
+
+from app.main import app
+
+__all__ = ["app"]

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/main.py": {
+      "runtime": "python3.11"
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/main.py": {
-      "runtime": "python3.11"
+      "runtime": "vercel-python@3.11"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add an api/main.py module that re-exports the existing FastAPI app for Vercel
- configure Vercel to use the new entrypoint via vercel.json

## Testing
- npx vercel@latest build *(fails: network unreachable while fetching Vercel package metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4fb64e4c833389781d42b98dbe45