### PR TITLE
Update Vercel Python runtime version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/main.py": {
+      "runtime": "vercel-python@3.11.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- specify the Vercel Python function runtime as vercel-python@3.11.0

## Testing
- npx vercel@latest build *(fails: ENETUNREACH when downloading project settings)*

------
https://chatgpt.com/codex/tasks/task_e_68cd932172a48333a339c0969df700c0