### PR TITLE
Add Vercel entrypoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,3 @@
+from app.main import app as app
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- add an api/main.py entrypoint that re-exports the FastAPI app for Vercel

## Testing
- `npx vercel@latest build` *(fails: unable to reach Vercel due to ENETUNREACH in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9741c1288333a680c5d531b8ef52